### PR TITLE
Add assignment and variable support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "RSpec - active spec file only",
+            "type": "Ruby",
+            "request": "launch",
+            "useBundler": true,
+            "pathToBundler": "/Users/yuanfeng/.rvm/gems/ruby-2.6.1/wrappers/bundle",
+            "pathToRDebugIDE": "/Users/yuanfeng/.rvm/gems/ruby-2.6.1/gems/ruby-debug-ide-0.7.2",
+            "debuggerPort": "1240",
+            "program": "/Users/yuanfeng/.rvm/gems/ruby-2.6.1/bin/rspec",
+            "args": [
+                "-I",
+                "${workspaceRoot}",
+                "${file}"
+            ]
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+0.4.0
+
+* Add variable assignment and reference ability

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    starlark_compiler (0.3.0)
+    starlark_compiler (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/starlark_compiler/ast.rb
+++ b/lib/starlark_compiler/ast.rb
@@ -72,6 +72,8 @@ module StarlarkCompiler
           False.new
         when Numeric
           Number.new(obj)
+        when Variable
+          Variable.new(obj)
         else
           raise Error, "#{obj.inspect} not convertible to Node"
         end
@@ -101,10 +103,27 @@ module StarlarkCompiler
       end
     end
 
+    class Variable < Node
+      attr_reader :var
+      def initialize(var)
+        raise "Only string type is allowed as a variable, got #{var.class}" unless var.is_a?(::String)
+        @var = var
+      end
+    end
+
     class Array < Node
       attr_reader :elements
       def initialize(elements)
         @elements = elements.map(&method(:node))
+      end
+    end
+
+    class Assignment < Node
+      attr_reader :name, :var
+      def initialize(name, var)
+        @name = name
+        raise "Unsupported type on rhs for assignment: #{var.class}" if [FunctionCall, MethodCall, Assignment].include?(var.class)
+        @var = var
       end
     end
 

--- a/lib/starlark_compiler/ast.rb
+++ b/lib/starlark_compiler/ast.rb
@@ -72,10 +72,8 @@ module StarlarkCompiler
           False.new
         when Numeric
           Number.new(obj)
-        when Variable
-          Variable.new(obj)
         else
-          raise Error, "#{obj.inspect} not convertible to Node"
+          raise Error, "Ruby stdlib type #{obj.inspect} not convertible to Node"
         end
       end
     end
@@ -103,10 +101,10 @@ module StarlarkCompiler
       end
     end
 
-    class Variable < Node
+    class VariableReference < Node
       attr_reader :var
       def initialize(var)
-        raise "Only string type is allowed as a variable, got #{var.class}" unless var.is_a?(::String)
+        raise "Only string type is allowed as a variable reference, got #{var.class}" unless var.is_a?(::String)
         @var = var
       end
     end
@@ -118,11 +116,11 @@ module StarlarkCompiler
       end
     end
 
-    class Assignment < Node
+    class VariableAssignment < Node
       attr_reader :name, :var
       def initialize(name, var)
         @name = name
-        raise "Unsupported type on rhs for assignment: #{var.class}" if [FunctionCall, MethodCall, Assignment].include?(var.class)
+        raise "Unsupported type on rhs for assignment: #{var.class}" if [Assignment].include?(var.class)
         @var = var
       end
     end

--- a/lib/starlark_compiler/ast.rb
+++ b/lib/starlark_compiler/ast.rb
@@ -104,7 +104,12 @@ module StarlarkCompiler
     class VariableReference < Node
       attr_reader :var
       def initialize(var)
-        raise "Only string type is allowed as a variable reference, got #{var.class}" unless var.is_a?(::String)
+        unless var.is_a?(::String)
+          raise ''"
+Only string type is allowed as a variable reference, got #{var.class}
+"''
+        end
+
         @var = var
       end
     end
@@ -120,7 +125,10 @@ module StarlarkCompiler
       attr_reader :name, :var
       def initialize(name, var)
         @name = name
-        raise "Unsupported type on rhs for assignment: #{var.class}" if [VariableAssignment].include?(var.class)
+        if [VariableAssignment].include?(var.class)
+          raise "Unsupported type on rhs for assignment: #{var.class}"
+        end
+
         @var = node(var)
       end
     end

--- a/lib/starlark_compiler/ast.rb
+++ b/lib/starlark_compiler/ast.rb
@@ -120,8 +120,8 @@ module StarlarkCompiler
       attr_reader :name, :var
       def initialize(name, var)
         @name = name
-        raise "Unsupported type on rhs for assignment: #{var.class}" if [Assignment].include?(var.class)
-        @var = var
+        raise "Unsupported type on rhs for assignment: #{var.class}" if [VariableAssignment].include?(var.class)
+        @var = node(var)
       end
     end
 

--- a/lib/starlark_compiler/build_file.rb
+++ b/lib/starlark_compiler/build_file.rb
@@ -8,7 +8,7 @@ module StarlarkCompiler
     def initialize(package:, workspace: Dir.pwd)
       @loads = Hash.new { |h, k| h[k] = Set.new }
       @targets = {}
-      @assignments = []
+      @variable_assignments = []
       @package = package
       @workspace = workspace
       @path = File.join(@workspace, @package, 'BUILD.bazel')
@@ -27,8 +27,8 @@ module StarlarkCompiler
       @targets[name] = function_call
     end
 
-    def add_assignment(name, var)
-      @assignments[name] = var
+    def add_variable_assignment(name, var)
+      @variable_assignments[name] = var
     end
 
     def save!
@@ -41,13 +41,13 @@ module StarlarkCompiler
       loads = @loads
               .sort_by { |k, _| k }
               .map { |f, fn| AST.build { function_call('load', f, *fn.sort) } }
-      assignments = @assignments
+      variable_assignments = @variable_assignments
               .sort_by { |k, _| k }
-              .map { |name, var| AST.build { assignment(name, var) } }
+              .map { |name, var| AST.build { variable_assignment(name, var) } }
       targets = @targets
                 .sort_by { |k, _| k }
                 .map { |_f, fn| normalize_function_call_kwargs(fn) }
-      AST.new(toplevel: loads + assignments + targets)
+      AST.new(toplevel: loads + variable_assignments + targets)
     end
 
     private

--- a/lib/starlark_compiler/build_file.rb
+++ b/lib/starlark_compiler/build_file.rb
@@ -42,8 +42,10 @@ module StarlarkCompiler
               .sort_by { |k, _| k }
               .map { |f, fn| AST.build { function_call('load', f, *fn.sort) } }
       variable_assignments = @variable_assignments
-              .sort_by { |k, _| k }
-              .map { |name, var| AST.build { variable_assignment(name, var) } }
+                             .sort_by { |k, _| k }
+                             .map do |name, var|
+                               AST.build { variable_assignment(name, var) }
+                             end
       targets = @targets
                 .sort_by { |k, _| k }
                 .map { |_f, fn| normalize_function_call_kwargs(fn) }

--- a/lib/starlark_compiler/build_file.rb
+++ b/lib/starlark_compiler/build_file.rb
@@ -8,7 +8,7 @@ module StarlarkCompiler
     def initialize(package:, workspace: Dir.pwd)
       @loads = Hash.new { |h, k| h[k] = Set.new }
       @targets = {}
-      @variable_assignments = []
+      @variable_assignments = {}
       @package = package
       @workspace = workspace
       @path = File.join(@workspace, @package, 'BUILD.bazel')
@@ -27,7 +27,7 @@ module StarlarkCompiler
       @targets[name] = function_call
     end
 
-    def add_variable_assignment(name, var)
+    def add_variable_assignment(name:, var:)
       @variable_assignments[name] = var
     end
 

--- a/lib/starlark_compiler/version.rb
+++ b/lib/starlark_compiler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StarlarkCompiler
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/lib/starlark_compiler/writer.rb
+++ b/lib/starlark_compiler/writer.rb
@@ -97,7 +97,6 @@ module StarlarkCompiler
       io << ')'
     end
 
-
     def write_variable_reference(variable)
       io << variable.var
     end

--- a/lib/starlark_compiler/writer.rb
+++ b/lib/starlark_compiler/writer.rb
@@ -97,6 +97,16 @@ module StarlarkCompiler
       io << ')'
     end
 
+
+    def write_variable(variable)
+      io << variable.var
+    end
+
+    def write_assignment(assignment)
+      io << assignment.name << ' = '
+      write_node(assignment.var)
+    end
+
     def write_array(array)
       single_line = single_line?(array)
       io << '['

--- a/lib/starlark_compiler/writer.rb
+++ b/lib/starlark_compiler/writer.rb
@@ -98,11 +98,11 @@ module StarlarkCompiler
     end
 
 
-    def write_variable(variable)
+    def write_variable_reference(variable)
       io << variable.var
     end
 
-    def write_assignment(assignment)
+    def write_variable_assignment(assignment)
       io << assignment.name << ' = '
       write_node(assignment.var)
     end

--- a/spec/starlark_compiler_spec.rb
+++ b/spec/starlark_compiler_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe StarlarkCompiler do
            ['A.swift']
       )
       ast << variable_assignment('deps', array([':App_Objc']))
-      ast << variable_assignment('numbers', array([1,2,3]))
+      ast << variable_assignment('numbers', array([1, 2, 3]))
       ast << function_call(
         'ios_application',
         name: string('App'),
@@ -263,10 +263,10 @@ RSpec.describe StarlarkCompiler do
       build_file.add_load(from: '@hello//:morning', of: 'efg')
 
       build_file.add_variable_assignment(name: 'foovar', var: 'bar')
-      build_file.add_variable_assignment(name: 'foovar2', var: ['bar1', 'bar2'])
+      build_file.add_variable_assignment(name: 'foovar2', var: %w[bar1 bar2])
 
       StarlarkCompiler::AST.build do
-        build_file.add_variable_assignment(name: 'foovar2', var: ['bar1', 'bar2'])
+        build_file.add_variable_assignment(name: 'foovar2', var: %w[bar1 bar2])
         build_file.add_target(function_call(
                                 'foo',
                                 name: 'Framework',
@@ -278,7 +278,11 @@ RSpec.describe StarlarkCompiler do
                                 do: nil,
                                 a_bit: true
                               ))
-        build_file.add_variable_assignment(name: 'fooTarget', var: function_call('foo', name: 'FooTarget'))
+        build_file.add_variable_assignment(
+          name: 'fooTarget',
+          var: function_call('foo',
+                             name: 'FooTarget')
+        )
         build_file.add_variable_assignment(name: 'fooBool', var: true)
         build_file.add_variable_assignment(name: 'fooNil', var: nil)
         build_file.add_variable_assignment(name: 'fooNumber', var: 10)


### PR DESCRIPTION
### Why this change
We want to enable writing the following using this:
```
bar = [1, 2, 3]
foo(name = 'abc', src = bar)

```
The first line illustrates assignments, and second line illustrates the ability to use the above assignment inside a function call

### TODO
- [x] Write full set of tests 
- [x] Update readme to reflect new features (and also write the expected output for easier understanding of that it does)
- [x] Update version