### PR TITLE
add FunctionDeclaration to AST

### DIFF
--- a/lib/starlark_compiler/ast.rb
+++ b/lib/starlark_compiler/ast.rb
@@ -143,6 +143,16 @@ module StarlarkCompiler
       end
     end
 
+    class FunctionDeclaration < Node
+      attr_reader :name, :args, :body, :kwargs
+      def initialize(name, args, body, **kwargs)
+        @name = name
+        @args = args.map(&method(:node))
+        @body = body.map(&method(:node))
+        @kwargs = kwargs.transform_values(&method(:node))
+      end
+    end
+
     class MethodCall < Node
     end
 

--- a/lib/starlark_compiler/writer.rb
+++ b/lib/starlark_compiler/writer.rb
@@ -97,6 +97,27 @@ module StarlarkCompiler
       io << ')'
     end
 
+    def write_function_declaration(declaration)
+      io << 'def ' << declaration.name << '('
+      final_index = declaration.args.size.pred
+      declaration.args.each_with_index do |arg, idx|
+        indented(single_line: false) do |indenter|
+          indenter.write_newline
+          write_node(arg)
+          indenter.write_comma unless final_index == idx
+        end
+      end
+      write_newline
+      io << '):'
+      final_index = declaration.body.size.pred
+      declaration.body.each_with_index do |arg, idx|
+        indented(single_line: false) do |indenter|
+          indenter.write_newline
+          write_node(arg)
+        end
+      end
+    end
+
     def write_variable_reference(variable)
       io << variable.var
     end
@@ -211,6 +232,10 @@ module StarlarkCompiler
     def single_line_dictionary?(dictionary)
       dictionary.elements.size <= 1 &&
         dictionary.elements.each_key.all?(&method(:single_line?))
+    end
+
+    def single_line_variable_reference?(_)
+      true
     end
   end
 end

--- a/lib/starlark_compiler/writer.rb
+++ b/lib/starlark_compiler/writer.rb
@@ -110,7 +110,7 @@ module StarlarkCompiler
       write_newline
       io << '):'
       final_index = declaration.body.size.pred
-      declaration.body.each_with_index do |arg, idx|
+      declaration.body.each do |arg|
         indented(single_line: false) do |indenter|
           indenter.write_newline
           write_node(arg)

--- a/spec/starlark_compiler_spec.rb
+++ b/spec/starlark_compiler_spec.rb
@@ -52,6 +52,24 @@ RSpec.describe StarlarkCompiler do
         deps: variable_reference('deps'),
         entitlements: array([string(':App.entitlements')])
       )
+      ast << function_declaration(
+        'newMacro',
+        [variable_reference('deps'), variable_reference('data')],
+        [
+          function_call(
+            'ios_application',
+            srcs: function_call('glob', array([string('Sources/**/*.swift')])),
+            deps: variable_reference('deps'),
+            data: variable_reference('data')
+          ),
+          function_call(
+            'ios_unit_test',
+            srcs: function_call('glob', array([string('Tests/**/*.swift')])),
+            deps: variable_reference('deps'),
+            data: variable_reference('data')
+          )
+        ]
+      )
       ast
     end
 
@@ -83,6 +101,21 @@ RSpec.describe StarlarkCompiler do
           deps = deps,
           entitlements = [":App.entitlements"],
       )
+
+      def newMacro(
+          deps,
+          data
+      ):
+          ios_application(
+              srcs = glob(["Sources/**/*.swift"]),
+              deps = deps,
+              data = data,
+          )
+          ios_unit_test(
+              srcs = glob(["Tests/**/*.swift"]),
+              deps = deps,
+              data = data,
+          )
     STARLARK
     check_buildifier(compiled)
   end


### PR DESCRIPTION
Adds a `FunctionDeclaration` that can have any number of parameters / lines in the body

Primary use is to define macros for bazel files:
```ruby
      ast << function_declaration(
        'newMacro',
        [variable_reference('deps'), variable_reference('data')],
        [
          function_call(
            'ios_application',
            srcs: function_call('glob', array([string('Sources/**/*.swift')])),
            deps: variable_reference('deps'),
            data: variable_reference('data')
          ),
          function_call(
            'ios_unit_test',
            srcs: function_call('glob', array([string('Tests/**/*.swift')])),
            deps: variable_reference('deps'),
            data: variable_reference('data')
          )
        ]
      )
```

outputs:
```starlark
      def newMacro(
          deps,
          data
      ):
          ios_application(
              srcs = glob(["Sources/**/*.swift"]),
              deps = deps,
              data = data,
          )
          ios_unit_test(
              srcs = glob(["Tests/**/*.swift"]),
              deps = deps,
              data = data,
          )
```

I'm intending on (and have some of it staged locally) adding an option to https://github.com/bazel-ios/cocoapods-bazel to generate the main build file as macros instead of a static build file, so as a user i can pass additional data/deps into the iOS build from other targets