### PR TITLE
Update gemspec to support Ruby 3.x

### DIFF
--- a/starlark_compiler.gemspec
+++ b/starlark_compiler.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.6'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
 end


### PR DESCRIPTION
While trying to update to Ruby 3.2.0, I got an error from `bundle install`

```
Could not find compatible versions

Because starlark_compiler >= 0.3.0, < 0.4.0 depends on Ruby ~> 2.6
  and starlark_compiler >= 0.4.0 depends on Ruby ~> 2.6,
  starlark_compiler >= 0.3.0 requires Ruby >= 2.6, < 3.A.
And because cocoapods-bazel >= 0.1.4, < 0.1.5 depends on starlark_compiler ~> 0.3,
  cocoapods-bazel >= 0.1.4, < 0.1.5 requires Ruby >= 2.6, < 3.A.
So, because Gemfile depends on cocoapods-bazel = 0.1.4
  and current Ruby version is = 3.2.0,
  version solving has failed.
```

This PR updates the gemspec for this ruby gem to support all ruby versions >= 2.6, instead of just 2.x releases.